### PR TITLE
Implemented Goals for Technical Test

### DIFF
--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -1,16 +1,31 @@
-import React from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { screen } from '@testing-library/react'
 import { render } from './test-utils'
 import { App } from './App'
+import { MockedProvider } from '@apollo/client/testing'
+import { CITIES } from './queries'
 
 describe('<App /> component', () => {
-  it('renders the Header content', () => {
+  it('renders the Header content', async () => {
+    const citiesMock = {
+      request: {
+        query: CITIES,
+      },
+      result: {
+        data: { cities: [] },
+      },
+    }
+
     render(
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </MockedProvider>
     )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
     const HeadingComponent = screen.getByText(/^Smart traveller$/i)
     expect(HeadingComponent).toBeInTheDocument()
   })

--- a/packages/client/src/App.test.tsx
+++ b/packages/client/src/App.test.tsx
@@ -7,17 +7,8 @@ import { CITIES } from './queries'
 
 describe('<App /> component', () => {
   it('renders the Header content', async () => {
-    const citiesMock = {
-      request: {
-        query: CITIES,
-      },
-      result: {
-        data: { cities: [] },
-      },
-    }
-
     render(
-      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+      <MockedProvider mocks={[]} addTypename={false}>
         <BrowserRouter>
           <App />
         </BrowserRouter>

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -3,9 +3,9 @@ import { Cities } from './Cities'
 
 describe('<Home /> component', () => {
   it('when no cities, No cities found text is rendered', async () => {
-    render(<Cities cities={[]} />)
+    render(<Cities cities={[]} filter="Utopia" />)
 
-    const noCitiesFound = screen.getByText('No cities have been found')
+    const noCitiesFound = screen.getByText("No cities have been found matching filter 'Utopia'")
     expect(noCitiesFound).toBeInTheDocument()
   })
 
@@ -14,14 +14,17 @@ describe('<Home /> component', () => {
       <Cities
         cities={[
           {
+            id: 1,
             name: 'London',
             country: 'United Kingdom',
           },
           {
+            id: 2,
             name: 'Moscow',
             country: 'Russia',
           },
         ]}
+        filter={'o'}
       />
     )
 

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { Cities } from './Cities'
+
+describe('<Home /> component', () => {
+  it('when no cities, No cities found text is rendered', async () => {
+    render(<Cities cities={[]} />)
+
+    const noCitiesFound = screen.getByText('No cities have been found')
+    expect(noCitiesFound).toBeInTheDocument()
+  })
+
+  it('when cities, cities table is rendered with expected cities', async () => {
+    render(
+      <Cities
+        cities={[
+          {
+            name: 'London',
+            country: 'United Kingdom',
+          },
+          {
+            name: 'Moscow',
+            country: 'Russia',
+          },
+        ]}
+      />
+    )
+
+    const london = screen.getByText('London')
+    const uk = screen.getByText('United Kingdom')
+    expect(london).toBeInTheDocument()
+    expect(uk).toBeInTheDocument()
+
+    const moscow = screen.getByText('Moscow')
+    const russia = screen.getByText('Russia')
+    expect(moscow).toBeInTheDocument()
+    expect(russia).toBeInTheDocument()
+  })
+})

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -1,9 +1,15 @@
-import { render, screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { UPDATE_CITY } from '../queries'
 import { Cities } from './Cities'
 
 describe('<Home /> component', () => {
   it('when no cities, No cities found text is rendered', async () => {
-    render(<Cities cities={[]} filter="Utopia" />)
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities cities={[]} filter="Utopia" />
+      </MockedProvider>
+    )
 
     const noCitiesFound = screen.getByText("No cities have been found matching filter 'Utopia'")
     expect(noCitiesFound).toBeInTheDocument()
@@ -11,21 +17,27 @@ describe('<Home /> component', () => {
 
   it('when cities, cities table is rendered with expected cities', async () => {
     render(
-      <Cities
-        cities={[
-          {
-            id: 1,
-            name: 'London',
-            country: 'United Kingdom',
-          },
-          {
-            id: 2,
-            name: 'Moscow',
-            country: 'Russia',
-          },
-        ]}
-        filter={'o'}
-      />
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: false,
+              wishlist: false,
+            },
+            {
+              id: 2,
+              name: 'Moscow',
+              country: 'Russia',
+              visited: false,
+              wishlist: false,
+            },
+          ]}
+          filter={'o'}
+        />
+      </MockedProvider>
     )
 
     const london = screen.getByText('London')
@@ -37,5 +49,179 @@ describe('<Home /> component', () => {
     const russia = screen.getByText('Russia')
     expect(moscow).toBeInTheDocument()
     expect(russia).toBeInTheDocument()
+  })
+
+  it('with cities the menu button is rendered', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: false,
+              wishlist: false,
+            },
+          ]}
+          filter={'London'}
+        />
+      </MockedProvider>
+    )
+
+    const menuButton = screen.getByRole('button')
+    expect(menuButton).toBeInTheDocument()
+  })
+
+  it('when city has not been visited or wish-listed, the visit/wishlist menu items are rendered', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: false,
+              wishlist: false,
+            },
+          ]}
+          filter={'London'}
+        />
+      </MockedProvider>
+    )
+
+    const visited = screen.getByText('Set visited')
+    expect(visited).toBeInTheDocument()
+
+    const wishlist = screen.getByText('Add to wishlist')
+    expect(wishlist).toBeInTheDocument()
+  })
+
+  it('when city has been visited or wish-listed, the un-visit/remove-wishlist menu items are rendered', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: true,
+              wishlist: true,
+            },
+          ]}
+          filter={'London'}
+        />
+      </MockedProvider>
+    )
+
+    const visited = screen.getByText('Set not visited')
+    expect(visited).toBeInTheDocument()
+
+    const wishlist = screen.getByText('Remove from wishlist')
+    expect(wishlist).toBeInTheDocument()
+  })
+
+  it('when visited menu item has been clicked, calls mutation', async () => {
+    const citiesMock = {
+      request: {
+        query: UPDATE_CITY,
+        variables: {
+          input: {
+            id: 1,
+            visited: true,
+          },
+        },
+      },
+      result: {
+        data: {
+          id: 1,
+          name: 'London',
+          country: 'United Kingdom',
+          visited: true,
+          wishlist: false,
+        },
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: false,
+              wishlist: false,
+            },
+          ]}
+          filter={'London'}
+        />
+      </MockedProvider>
+    )
+
+    const visitedButton = screen.getByText('Set visited')
+    fireEvent(
+      visitedButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+  })
+
+  it('when wishlist menu item has been clicked, calls mutation', async () => {
+    const citiesMock = {
+      request: {
+        query: UPDATE_CITY,
+        variables: {
+          input: {
+            id: 1,
+            wishlist: true,
+          },
+        },
+      },
+      result: {
+        data: {
+          id: 1,
+          name: 'London',
+          country: 'United Kingdom',
+          visited: false,
+          wishlist: true,
+        },
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: false,
+              wishlist: false,
+            },
+          ]}
+          filter={'London'}
+        />
+      </MockedProvider>
+    )
+
+    const wishlistButton = screen.getByText('Add to wishlist')
+    fireEvent(
+      wishlistButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
   })
 })

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -4,14 +4,25 @@ import { UpdateCityRequestSeeder } from '../test-utils'
 import { Cities } from './Cities'
 
 describe('<Home /> component', () => {
-  it('when no cities, No cities found text is rendered', async () => {
+  it('when no cities with filter, No cities found text with filter is rendered', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
-        <Cities cities={[]} filter="Utopia" />
+        <Cities cities={[]} filter="Utopia" isLoading={false} />
       </MockedProvider>
     )
 
     const noCitiesFound = screen.getByText("No cities have been found matching filter 'Utopia'")
+    expect(noCitiesFound).toBeInTheDocument()
+  })
+
+  it('when no cities and no filer, No cities found text is rendered', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities cities={[]} isLoading={false} />
+      </MockedProvider>
+    )
+
+    const noCitiesFound = screen.getByText('No cities have been found')
     expect(noCitiesFound).toBeInTheDocument()
   })
 
@@ -36,6 +47,7 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'o'}
+          isLoading={false}
         />
       </MockedProvider>
     )
@@ -65,6 +77,7 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
+          isLoading={false}
         />
       </MockedProvider>
     )
@@ -87,6 +100,7 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
+          isLoading={false}
         />
       </MockedProvider>
     )
@@ -112,6 +126,7 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
+          isLoading={false}
         />
       </MockedProvider>
     )
@@ -139,6 +154,7 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
+          isLoading={false}
         />
       </MockedProvider>
     )
@@ -171,6 +187,7 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
+          isLoading={false}
         />
       </MockedProvider>
     )
@@ -185,5 +202,15 @@ describe('<Home /> component', () => {
     )
 
     await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+  })
+
+  it('when isLoading renders skeleton', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities cities={[]} isLoading={true} />
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('cities-loading')).toBeInTheDocument()
   })
 })

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { UPDATE_CITY } from '../queries'
+import { UpdateCityRequestSeeder } from '../test-utils'
 import { Cities } from './Cities'
 
 describe('<Home /> component', () => {
@@ -124,26 +124,7 @@ describe('<Home /> component', () => {
   })
 
   it('when visited menu item has been clicked, calls mutation', async () => {
-    const citiesMock = {
-      request: {
-        query: UPDATE_CITY,
-        variables: {
-          input: {
-            id: 1,
-            visited: true,
-          },
-        },
-      },
-      result: {
-        data: {
-          id: 1,
-          name: 'London',
-          country: 'United Kingdom',
-          visited: true,
-          wishlist: false,
-        },
-      },
-    }
+    const citiesMock = new UpdateCityRequestSeeder().UpdateVisited(true)
 
     render(
       <MockedProvider mocks={[citiesMock]} addTypename={false}>
@@ -175,26 +156,7 @@ describe('<Home /> component', () => {
   })
 
   it('when wishlist menu item has been clicked, calls mutation', async () => {
-    const citiesMock = {
-      request: {
-        query: UPDATE_CITY,
-        variables: {
-          input: {
-            id: 1,
-            wishlist: true,
-          },
-        },
-      },
-      result: {
-        data: {
-          id: 1,
-          name: 'London',
-          country: 'United Kingdom',
-          visited: false,
-          wishlist: true,
-        },
-      },
-    }
+    const citiesMock = new UpdateCityRequestSeeder().UpdateWishlist(true)
 
     render(
       <MockedProvider mocks={[citiesMock]} addTypename={false}>

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -1,9 +1,10 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { CityResponse } from '../queries'
 import { UpdateCityRequestSeeder } from '../test-utils'
 import { Cities } from './Cities'
 
-describe('<Home /> component', () => {
+describe('<Cities /> component', () => {
   it('when no cities with filter, No cities found text with filter is rendered', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
@@ -246,5 +247,118 @@ describe('<Home /> component', () => {
     )
 
     expect(screen.getByTestId('cities-loading')).toBeInTheDocument()
+  })
+
+  it('does not show paging options when paging is undefined', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities cities={[]} />
+      </MockedProvider>
+    )
+
+    expect(screen.queryByRole('button', { name: 'Previous' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument()
+  })
+
+  it('shows paging options when paging is set', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities cities={[]} pagination={{ onNextClicked: () => {}, onPreviousClicked: () => {} }} />
+      </MockedProvider>
+    )
+
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+  })
+
+  it('handles next callback when next paging options is clicked', async () => {
+    const nextCallback = jest.fn()
+    const previousCallback = jest.fn()
+
+    const lnd: CityResponse = { id: 0, country: 'UK', name: 'London', visited: false, wishlist: false }
+
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd]} // Needs 10 or more for button to not be disabled
+          pagination={{ onNextClicked: nextCallback, onPreviousClicked: previousCallback }}
+        />
+      </MockedProvider>
+    )
+
+    const nextButton = screen.getByRole('button', { name: 'Next' })
+    fireEvent(
+      nextButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(nextCallback).toHaveBeenCalledTimes(1)
+    expect(previousCallback).not.toHaveBeenCalled()
+  })
+
+  it('handles previous callback when next paging options is clicked', async () => {
+    const nextCallback = jest.fn()
+    const previousCallback = jest.fn()
+    const lnd: CityResponse = { id: 0, country: 'UK', name: 'London', visited: false, wishlist: false }
+
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd]} // Needs 10 or more for button to not be disabled
+          pagination={{ onNextClicked: nextCallback, onPreviousClicked: previousCallback }}
+        />
+      </MockedProvider>
+    )
+
+    const previousButton = screen.getByRole('button', { name: 'Previous' })
+    fireEvent(
+      previousButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(nextCallback).not.toHaveBeenCalled()
+    expect(previousCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('callbacks never fire when 9 or less cities are provided', async () => {
+    const nextCallback = jest.fn()
+    const previousCallback = jest.fn()
+    const lnd: CityResponse = { id: 0, country: 'UK', name: 'London', visited: false, wishlist: false }
+
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd]} // 9 cities so the button is disabled
+          pagination={{ onNextClicked: nextCallback, onPreviousClicked: previousCallback }}
+        />
+      </MockedProvider>
+    )
+
+    const previousButton = screen.getByRole('button', { name: 'Previous' })
+    fireEvent(
+      previousButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    const nextButton = screen.getByRole('button', { name: 'Next' })
+    fireEvent(
+      nextButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(nextCallback).not.toHaveBeenCalled()
+    expect(previousCallback).not.toHaveBeenCalled()
   })
 })

--- a/packages/client/src/Cities/Cities.test.tsx
+++ b/packages/client/src/Cities/Cities.test.tsx
@@ -7,7 +7,7 @@ describe('<Home /> component', () => {
   it('when no cities with filter, No cities found text with filter is rendered', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
-        <Cities cities={[]} filter="Utopia" isLoading={false} />
+        <Cities cities={[]} filter="Utopia" />
       </MockedProvider>
     )
 
@@ -18,7 +18,7 @@ describe('<Home /> component', () => {
   it('when no cities and no filer, No cities found text is rendered', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
-        <Cities cities={[]} isLoading={false} />
+        <Cities cities={[]} />
       </MockedProvider>
     )
 
@@ -47,7 +47,6 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'o'}
-          isLoading={false}
         />
       </MockedProvider>
     )
@@ -61,6 +60,46 @@ describe('<Home /> component', () => {
     const russia = screen.getByText('Russia')
     expect(moscow).toBeInTheDocument()
     expect(russia).toBeInTheDocument()
+  })
+
+  it('When cities and isReadOnly, cities table is rendered with expected cities and no edit visited/wishlist buttons', () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Cities
+          cities={[
+            {
+              id: 1,
+              name: 'London',
+              country: 'United Kingdom',
+              visited: false,
+              wishlist: false,
+            },
+            {
+              id: 2,
+              name: 'Moscow',
+              country: 'Russia',
+              visited: false,
+              wishlist: false,
+            },
+          ]}
+          filter={'o'}
+          isReadonly={true}
+        />
+      </MockedProvider>
+    )
+
+    const london = screen.getByText('London')
+    const uk = screen.getByText('United Kingdom')
+    expect(london).toBeInTheDocument()
+    expect(uk).toBeInTheDocument()
+
+    const moscow = screen.getByText('Moscow')
+    const russia = screen.getByText('Russia')
+    expect(moscow).toBeInTheDocument()
+    expect(russia).toBeInTheDocument()
+
+    const menuButton = screen.queryByRole('button')
+    expect(menuButton).not.toBeInTheDocument()
   })
 
   it('with cities the menu button is rendered', async () => {
@@ -77,7 +116,6 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
-          isLoading={false}
         />
       </MockedProvider>
     )
@@ -100,7 +138,6 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
-          isLoading={false}
         />
       </MockedProvider>
     )
@@ -126,7 +163,6 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
-          isLoading={false}
         />
       </MockedProvider>
     )
@@ -154,7 +190,6 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
-          isLoading={false}
         />
       </MockedProvider>
     )
@@ -187,7 +222,6 @@ describe('<Home /> component', () => {
             },
           ]}
           filter={'London'}
-          isLoading={false}
         />
       </MockedProvider>
     )

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -1,0 +1,22 @@
+import { Table, TableCaption, Tbody, Td, Tfoot, Th, Thead, Tr, useId } from '@chakra-ui/react'
+import { FC } from 'react'
+import { City } from '../../../api/src/cities/types'
+
+export interface Props {
+  cities: ReadonlyArray<City>
+}
+
+export const Cities: FC<Props> = (props: Props) => {
+  return (
+    <Table data-testid="cities" variant="simple">
+      <TableCaption>Imperial to metric conversion factors</TableCaption>
+      <Thead>
+        <Tr>
+          <Th>Name</Th>
+          <Th>Country</Th>
+        </Tr>
+      </Thead>
+      <Tbody></Tbody>
+    </Table>
+  )
+}

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -3,13 +3,16 @@ import { FC } from 'react'
 import { CityResponse } from '../queries'
 
 export interface Props {
+  filter: string | undefined
   cities: ReadonlyArray<CityResponse>
 }
 
 export const Cities: FC<Props> = (props: Props) => {
   return (
     <Table data-testid="cities" variant="simple">
-      {props.cities.length === 0 && <TableCaption>No cities have been found</TableCaption>}
+      {props.cities.length === 0 && (
+        <TableCaption>No cities have been found matching filter '{props.filter}'</TableCaption>
+      )}
       <Thead>
         <Tr>
           <Th>Name</Th>
@@ -18,7 +21,7 @@ export const Cities: FC<Props> = (props: Props) => {
       </Thead>
       <Tbody>
         {props.cities.map(city => (
-          <Tr>
+          <Tr key={city.id}>
             <Td>{city.name}</Td>
             <Td>{city.country}</Td>
           </Tr>

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from '@apollo/client'
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons'
 import {
   Button,
   Menu,
@@ -11,6 +12,7 @@ import {
   TableCaption,
   Tbody,
   Td,
+  Tfoot,
   Th,
   Thead,
   Tr,
@@ -18,11 +20,38 @@ import {
 import { FC } from 'react'
 import { CitiesMutationInput, CityResponse, UPDATE_CITY } from '../queries'
 
+export interface Paging {
+  onPreviousClicked: () => void
+  onNextClicked: () => void
+}
+
 export interface Props {
-  filter?: string
+  /**
+   * The cities to render, if null supplied then the Cities table is not rendered.
+   */
   cities: ReadonlyArray<CityResponse> | undefined
+
+  /**
+   * The filter text that was used to display return the supplied cities.
+   */
+  filter?: string
+
+  /**
+   * Whether the cities component is loading or not. If not it will render Skeletons, otherwise the provided cities.
+   * @default false
+   */
   isLoading?: boolean
+
+  /**
+   * Whether the user can update visited or wishlist for each city.
+   * @default false
+   */
   isReadonly?: boolean
+
+  /**
+   * Whether to implement paging buttons with callbacks or not.
+   */
+  pagination?: Paging | undefined
 }
 
 export const Cities: FC<Props> = (props: Props) => {
@@ -54,7 +83,7 @@ export const Cities: FC<Props> = (props: Props) => {
 
   if (isLoading) {
     return (
-      <Stack mt="5px" data-testid="cities-loading">
+      <Stack mt="10px" data-testid="cities-loading">
         <Skeleton height="20px" />
         <Skeleton height="20px" />
         <Skeleton height="20px" />
@@ -112,6 +141,31 @@ export const Cities: FC<Props> = (props: Props) => {
           </Tr>
         ))}
       </Tbody>
+      {props.pagination != undefined && (
+        <Tfoot>
+          <Tr>
+            <Th>
+              <Button
+                leftIcon={<ChevronLeftIcon />}
+                onClick={props.pagination.onPreviousClicked}
+                disabled={props.cities.length < 10}
+              >
+                Previous
+              </Button>
+            </Th>
+            <Th></Th>
+            <Th>
+              <Button
+                rightIcon={<ChevronRightIcon />}
+                onClick={props.pagination.onNextClicked}
+                disabled={props.cities.length < 10}
+              >
+                Next
+              </Button>
+            </Th>
+          </Tr>
+        </Tfoot>
+      )}
     </Table>
   )
 }

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -5,6 +5,8 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
+  Skeleton,
+  Stack,
   Table,
   TableCaption,
   Tbody,
@@ -17,8 +19,9 @@ import { FC } from 'react'
 import { CitiesMutationInput, CityResponse, UPDATE_CITY } from '../queries'
 
 export interface Props {
-  filter: string | undefined
-  cities: ReadonlyArray<CityResponse>
+  filter?: string
+  cities: ReadonlyArray<CityResponse> | undefined
+  isLoading: boolean
 }
 
 export const Cities: FC<Props> = (props: Props) => {
@@ -34,6 +37,7 @@ export const Cities: FC<Props> = (props: Props) => {
       },
     })
   }
+
   const handleWishlistClicked = (id: number, wishlist: boolean) => {
     updateCity({
       variables: {
@@ -45,10 +49,26 @@ export const Cities: FC<Props> = (props: Props) => {
     })
   }
 
+  if (props.isLoading) {
+    return (
+      <Stack mt="5px" data-testid="cities-loading">
+        <Skeleton height="20px" />
+        <Skeleton height="20px" />
+        <Skeleton height="20px" />
+      </Stack>
+    )
+  }
+
+  if (props.cities == undefined) {
+    return <></> // Nothing to show, this is the initial state
+  }
+
   return (
     <Table data-testid="cities" variant="simple">
       {props.cities.length === 0 && (
-        <TableCaption>No cities have been found matching filter '{props.filter}'</TableCaption>
+        <TableCaption>
+          No cities have been found {props.filter == undefined ? '' : `matching filter '${props.filter}'`}
+        </TableCaption>
       )}
       <Thead>
         <Tr>

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -1,22 +1,29 @@
-import { Table, TableCaption, Tbody, Td, Tfoot, Th, Thead, Tr, useId } from '@chakra-ui/react'
+import { Table, TableCaption, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
 import { FC } from 'react'
-import { City } from '../../../api/src/cities/types'
+import { CityResponse } from '../queries'
 
 export interface Props {
-  cities: ReadonlyArray<City>
+  cities: ReadonlyArray<CityResponse>
 }
 
 export const Cities: FC<Props> = (props: Props) => {
   return (
     <Table data-testid="cities" variant="simple">
-      <TableCaption>Imperial to metric conversion factors</TableCaption>
+      {props.cities.length === 0 && <TableCaption>No cities have been found</TableCaption>}
       <Thead>
         <Tr>
           <Th>Name</Th>
           <Th>Country</Th>
         </Tr>
       </Thead>
-      <Tbody></Tbody>
+      <Tbody>
+        {props.cities.map(city => (
+          <Tr>
+            <Td>{city.name}</Td>
+            <Td>{city.country}</Td>
+          </Tr>
+        ))}
+      </Tbody>
     </Table>
   )
 }

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -1,6 +1,20 @@
-import { Table, TableCaption, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
+import { useMutation } from '@apollo/client'
+import {
+  Button,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Table,
+  TableCaption,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react'
 import { FC } from 'react'
-import { CityResponse } from '../queries'
+import { CitiesMutationInput, CityResponse, UPDATE_CITY } from '../queries'
 
 export interface Props {
   filter: string | undefined
@@ -8,6 +22,29 @@ export interface Props {
 }
 
 export const Cities: FC<Props> = (props: Props) => {
+  const [updateCity] = useMutation<CityResponse, CitiesMutationInput>(UPDATE_CITY)
+
+  const handleVisitedClicked = (id: number, visited: boolean) => {
+    updateCity({
+      variables: {
+        input: {
+          id: id,
+          visited: visited,
+        },
+      },
+    })
+  }
+  const handleWishlistClicked = (id: number, wishlist: boolean) => {
+    updateCity({
+      variables: {
+        input: {
+          id: id,
+          wishlist: wishlist,
+        },
+      },
+    })
+  }
+
   return (
     <Table data-testid="cities" variant="simple">
       {props.cities.length === 0 && (
@@ -17,6 +54,7 @@ export const Cities: FC<Props> = (props: Props) => {
         <Tr>
           <Th>Name</Th>
           <Th>Country</Th>
+          <Th></Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -24,6 +62,28 @@ export const Cities: FC<Props> = (props: Props) => {
           <Tr key={city.id}>
             <Td>{city.name}</Td>
             <Td>{city.country}</Td>
+            <Td>
+              <Menu>
+                <MenuButton as={Button}>...</MenuButton>
+                <MenuList>
+                  <MenuItem
+                    data-testid="visited-button"
+                    onClick={() => {
+                      handleVisitedClicked(city.id, !city.visited)
+                    }}
+                  >
+                    {city.visited ? 'Set not visited' : 'Set visited'}
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      handleWishlistClicked(city.id, !city.wishlist)
+                    }}
+                  >
+                    {city.wishlist ? 'Remove from wishlist' : 'Add to wishlist'}
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+            </Td>
           </Tr>
         ))}
       </Tbody>

--- a/packages/client/src/Cities/Cities.tsx
+++ b/packages/client/src/Cities/Cities.tsx
@@ -21,11 +21,14 @@ import { CitiesMutationInput, CityResponse, UPDATE_CITY } from '../queries'
 export interface Props {
   filter?: string
   cities: ReadonlyArray<CityResponse> | undefined
-  isLoading: boolean
+  isLoading?: boolean
+  isReadonly?: boolean
 }
 
 export const Cities: FC<Props> = (props: Props) => {
   const [updateCity] = useMutation<CityResponse, CitiesMutationInput>(UPDATE_CITY)
+  const isLoading = props.isLoading == undefined ? false : props.isLoading
+  const isReadonly = props.isReadonly == undefined ? false : props.isReadonly
 
   const handleVisitedClicked = (id: number, visited: boolean) => {
     updateCity({
@@ -49,7 +52,7 @@ export const Cities: FC<Props> = (props: Props) => {
     })
   }
 
-  if (props.isLoading) {
+  if (isLoading) {
     return (
       <Stack mt="5px" data-testid="cities-loading">
         <Skeleton height="20px" />
@@ -74,7 +77,7 @@ export const Cities: FC<Props> = (props: Props) => {
         <Tr>
           <Th>Name</Th>
           <Th>Country</Th>
-          <Th></Th>
+          {!isReadonly && <Th></Th>}
         </Tr>
       </Thead>
       <Tbody>
@@ -82,28 +85,30 @@ export const Cities: FC<Props> = (props: Props) => {
           <Tr key={city.id}>
             <Td>{city.name}</Td>
             <Td>{city.country}</Td>
-            <Td>
-              <Menu>
-                <MenuButton as={Button}>...</MenuButton>
-                <MenuList>
-                  <MenuItem
-                    data-testid="visited-button"
-                    onClick={() => {
-                      handleVisitedClicked(city.id, !city.visited)
-                    }}
-                  >
-                    {city.visited ? 'Set not visited' : 'Set visited'}
-                  </MenuItem>
-                  <MenuItem
-                    onClick={() => {
-                      handleWishlistClicked(city.id, !city.wishlist)
-                    }}
-                  >
-                    {city.wishlist ? 'Remove from wishlist' : 'Add to wishlist'}
-                  </MenuItem>
-                </MenuList>
-              </Menu>
-            </Td>
+            {!isReadonly && (
+              <Td>
+                <Menu>
+                  <MenuButton as={Button}>...</MenuButton>
+                  <MenuList>
+                    <MenuItem
+                      data-testid="visited-button"
+                      onClick={() => {
+                        handleVisitedClicked(city.id, !city.visited)
+                      }}
+                    >
+                      {city.visited ? 'Set not visited' : 'Set visited'}
+                    </MenuItem>
+                    <MenuItem
+                      onClick={() => {
+                        handleWishlistClicked(city.id, !city.wishlist)
+                      }}
+                    >
+                      {city.wishlist ? 'Remove from wishlist' : 'Add to wishlist'}
+                    </MenuItem>
+                  </MenuList>
+                </Menu>
+              </Td>
+            )}
           </Tr>
         ))}
       </Tbody>

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -1,10 +1,7 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
-import { render } from './test-utils'
+import { GetCitiesRequestSeeder, render } from './test-utils'
 import { Home } from './Home'
-import { CITIES } from './queries'
-import { GraphQLError } from 'graphql'
-import { Button } from '@chakra-ui/react'
 
 describe('<Home /> component', () => {
   it('renders the search box input', async () => {
@@ -60,14 +57,7 @@ describe('<Home /> component', () => {
   })
 
   it('when search fails it renders the error text', async () => {
-    const citiesMock = {
-      request: {
-        query: CITIES,
-      },
-      result: {
-        errors: [new GraphQLError('Error!')],
-      },
-    }
+    var citiesMock = new GetCitiesRequestSeeder().RespondsWithError()
 
     render(
       <MockedProvider mocks={[citiesMock]} addTypename={false}>
@@ -91,26 +81,7 @@ describe('<Home /> component', () => {
   })
 
   it('when search returns data it renders the <Cities /> component', async () => {
-    const citiesMock = {
-      request: {
-        query: CITIES,
-        variables: {
-          filter: {
-            name: undefined,
-          },
-        },
-      },
-      result: {
-        data: {
-          cities: {
-            cities: [
-              { id: 1, name: 'London', country: 'United Kingdom' },
-              { id: 1, name: 'Moscow', country: 'Russia' },
-            ],
-          },
-        },
-      },
-    }
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithCities()
 
     render(
       <MockedProvider mocks={[citiesMock]} addTypename={false}>
@@ -133,19 +104,15 @@ describe('<Home /> component', () => {
   })
 
   it('when search returns data with filter it renders the <Cities /> component', async () => {
-    const citiesMock = {
-      request: {
-        query: CITIES,
-        variables: {
-          filter: {
-            name: 'London',
-          },
-        },
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithCities('London', [
+      {
+        id: 1,
+        name: 'London',
+        country: 'United Kingdom',
+        visited: false,
+        wishlist: false,
       },
-      result: {
-        data: { cities: { cities: [{ id: 1, name: 'London', country: 'United Kingdom' }] } },
-      },
-    }
+    ])
 
     render(
       <MockedProvider mocks={[citiesMock]} addTypename={false}>
@@ -171,19 +138,7 @@ describe('<Home /> component', () => {
   })
 
   it('when search returns empty result due to filter not matching it renders the <Cities /> component', async () => {
-    const citiesMock = {
-      request: {
-        query: CITIES,
-        variables: {
-          filter: {
-            name: 'Utopia',
-          },
-        },
-      },
-      result: {
-        data: { cities: { cities: [] } },
-      },
-    }
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithCities('Utopia', [])
 
     render(
       <MockedProvider mocks={[citiesMock]} addTypename={false}>

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -1,23 +1,65 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { render } from './test-utils'
 import { Home } from './Home'
 import { CITIES } from './queries'
 import { GraphQLError } from 'graphql'
+import { Button } from '@chakra-ui/react'
 
 describe('<Home /> component', () => {
-  it('when still loading it displays the loading text', async () => {
+  it('renders the search box input', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
         <Home />
       </MockedProvider>
     )
 
-    const loading = screen.getByText('Loading...')
-    expect(loading).toBeInTheDocument()
+    const input = screen.getByRole('searchbox')
+    expect(input).toBeInTheDocument()
   })
 
-  it('when load fails it displays the error text', async () => {
+  it('renders the search button', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    const searchButton = screen.getByRole('button')
+    expect(searchButton).toBeInTheDocument()
+  })
+
+  it('when no search has occurred then cities is not rendered', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    expect(screen.queryByTestId('cities')).not.toBeInTheDocument()
+  })
+
+  it('when loading after search button clicked it renders the loading text', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    const error = screen.getByText('Loading...')
+    expect(error).toBeInTheDocument()
+  })
+
+  it('when search fails it renders the error text', async () => {
     const citiesMock = {
       request: {
         query: CITIES,
@@ -33,19 +75,40 @@ describe('<Home /> component', () => {
       </MockedProvider>
     )
 
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
     await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
 
     const error = screen.getByText('Error!')
     expect(error).toBeInTheDocument()
   })
 
-  it('loads and displays the <Cities /> component', async () => {
+  it('when search returns data it renders the <Cities /> component', async () => {
     const citiesMock = {
       request: {
         query: CITIES,
+        variables: {
+          filter: {
+            name: undefined,
+          },
+        },
       },
       result: {
-        data: { cities: { cities: { id: 1, name: 'London', country: 'United Kingdom' } } },
+        data: {
+          cities: {
+            cities: [
+              { id: 1, name: 'London', country: 'United Kingdom' },
+              { id: 1, name: 'Moscow', country: 'Russia' },
+            ],
+          },
+        },
       },
     }
 
@@ -53,6 +116,91 @@ describe('<Home /> component', () => {
       <MockedProvider mocks={[citiesMock]} addTypename={false}>
         <Home />
       </MockedProvider>
+    )
+
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+  })
+
+  it('when search returns data with filter it renders the <Cities /> component', async () => {
+    const citiesMock = {
+      request: {
+        query: CITIES,
+        variables: {
+          filter: {
+            name: 'London',
+          },
+        },
+      },
+      result: {
+        data: { cities: { cities: [{ id: 1, name: 'London', country: 'United Kingdom' }] } },
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    const searchBox = screen.getByRole('searchbox')
+    fireEvent.change(searchBox, { target: { value: 'London' } })
+
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+  })
+
+  it('when search returns empty result due to filter not matching it renders the <Cities /> component', async () => {
+    const citiesMock = {
+      request: {
+        query: CITIES,
+        variables: {
+          filter: {
+            name: 'Utopia',
+          },
+        },
+      },
+      result: {
+        data: { cities: { cities: [] } },
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    const searchBox = screen.getByRole('searchbox')
+    fireEvent.change(searchBox, { target: { value: 'Utopia' } })
+
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
     )
 
     await new Promise(resolve => setTimeout(resolve, 0)) // wait for response

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -1,0 +1,26 @@
+import { screen, waitFor } from '@testing-library/react'
+import { render } from './test-utils'
+import { Home } from './Home'
+
+describe('<Home /> component', () => {
+  it('renders the Smart traveller header', () => {
+    render(<Home />)
+
+    const HeadingComponent = screen.getByText(/^Smart traveller$/i)
+    expect(HeadingComponent).toBeInTheDocument()
+  })
+
+  it('when no cities, the <Cities /> component is not rendered', async () => {
+    render(<Home />)
+    expect(screen.queryByTestId('cities')).toBeNull()
+  })
+
+  it('loads and displays the <Cities /> comonent with expected cities count', async () => {
+    render(<Home />)
+
+    await waitFor(() => screen.getByTestId('cities'))
+
+    expect(screen.getByTestId('cities')).toHaveTextContent('London')
+    expect(screen.getByTestId('cities')).toHaveTextContent('Brighton')
+  })
+})

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -6,15 +6,6 @@ import { CITIES } from './queries'
 import { GraphQLError } from 'graphql'
 
 describe('<Home /> component', () => {
-  it('when no cities, the <Cities /> component is not rendered', async () => {
-    render(
-      <MockedProvider mocks={[]} addTypename={false}>
-        <Home />
-      </MockedProvider>
-    )
-    expect(screen.queryByTestId('cities')).toBeNull()
-  })
-
   it('when still loading it displays the loading text', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>
@@ -54,7 +45,7 @@ describe('<Home /> component', () => {
         query: CITIES,
       },
       result: {
-        data: { cities: { id: 1, name: 'London', country: 'United Kingdom' } },
+        data: { cities: { cities: { id: 1, name: 'London', country: 'United Kingdom' } } },
       },
     }
 

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -6,19 +6,6 @@ import { CITIES } from './queries'
 import { GraphQLError } from 'graphql'
 
 describe('<Home /> component', () => {
-  it('renders the Smart traveller header', async () => {
-    render(
-      <MockedProvider mocks={[]} addTypename={false}>
-        <Home />
-      </MockedProvider>
-    )
-
-    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
-
-    const HeadingComponent = screen.getByText(/^Smart traveller$/i)
-    expect(HeadingComponent).toBeInTheDocument()
-  })
-
   it('when no cities, the <Cities /> component is not rendered', async () => {
     render(
       <MockedProvider mocks={[]} addTypename={false}>

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { GetCitiesRequestSeeder, render } from './test-utils'
 import { Home } from './Home'
+import { CityResponse } from './queries'
 
 describe('<Home /> component', () => {
   it('renders the search box input', async () => {
@@ -160,5 +161,97 @@ describe('<Home /> component', () => {
     await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
 
     expect(screen.getByTestId('cities')).toBeInTheDocument()
+  })
+
+  it('fetches with new offset when next button is clicked and then previous button is clicked', async () => {
+    const lnd: CityResponse = { id: 0, country: 'UK', name: 'London', visited: false, wishlist: false }
+    const mos: CityResponse = { id: 1, country: 'Russia', name: 'Moscow', visited: false, wishlist: false }
+    const stPeter: CityResponse = {
+      id: 2,
+      country: 'Russia',
+      name: 'Saint Petersburg',
+      visited: false,
+      wishlist: false,
+    }
+
+    const citiesMockOffset0 = new GetCitiesRequestSeeder().RespondsWithCities(
+      undefined,
+      [lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd, lnd],
+      0
+    )
+    const citiesMockOffset10 = new GetCitiesRequestSeeder().RespondsWithCities(
+      undefined,
+      [mos, mos, mos, mos, mos, mos, mos, mos, mos, mos],
+      10
+    )
+    const citiesMockOffsetPrev0 = new GetCitiesRequestSeeder().RespondsWithCities(
+      undefined,
+      [stPeter, stPeter, stPeter, stPeter, stPeter, stPeter, stPeter, stPeter, stPeter, stPeter],
+      0
+    )
+
+    render(
+      <MockedProvider mocks={[citiesMockOffset0, citiesMockOffset10, citiesMockOffsetPrev0]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    // Initial Search
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+    expect(screen.getAllByText('London')).toHaveLength(10)
+
+    // Next Button Clicked Once
+
+    const nextButton = screen.getByRole('button', { name: 'Next' })
+    fireEvent(
+      nextButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+    expect(screen.getAllByText('Moscow')).toHaveLength(10)
+
+    // Previous Button Clicked Once
+
+    const previousButton = screen.getByRole('button', { name: 'Previous' })
+    fireEvent(
+      previousButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+    expect(screen.getAllByText('Saint Petersburg')).toHaveLength(10)
+
+    // Clicking Previous Button again does nothing
+    fireEvent(
+      previousButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+    expect(screen.getAllByText('Saint Petersburg')).toHaveLength(10)
   })
 })

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -36,26 +36,6 @@ describe('<Home /> component', () => {
     expect(screen.queryByTestId('cities')).not.toBeInTheDocument()
   })
 
-  it('when loading after search button clicked it renders the loading text', async () => {
-    render(
-      <MockedProvider mocks={[]} addTypename={false}>
-        <Home />
-      </MockedProvider>
-    )
-
-    const searchButton = screen.getByRole('button')
-    fireEvent(
-      searchButton,
-      new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-      })
-    )
-
-    const error = screen.getByText('Loading...')
-    expect(error).toBeInTheDocument()
-  })
-
   it('when search fails it renders the error text', async () => {
     var citiesMock = new GetCitiesRequestSeeder().RespondsWithError()
 
@@ -78,6 +58,25 @@ describe('<Home /> component', () => {
 
     const error = screen.getByText('Error!')
     expect(error).toBeInTheDocument()
+  })
+
+  it('while loading after search button clicked it renders <Cities /> component in loading state', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    const searchButton = screen.getByRole('button')
+    fireEvent(
+      searchButton,
+      new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+      })
+    )
+
+    expect(screen.getByTestId('cities-loading')).toBeInTheDocument()
   })
 
   it('when search returns data it renders the <Cities /> component', async () => {

--- a/packages/client/src/Home.test.tsx
+++ b/packages/client/src/Home.test.tsx
@@ -1,26 +1,84 @@
 import { screen, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
 import { render } from './test-utils'
 import { Home } from './Home'
+import { CITIES } from './queries'
+import { GraphQLError } from 'graphql'
 
 describe('<Home /> component', () => {
-  it('renders the Smart traveller header', () => {
-    render(<Home />)
+  it('renders the Smart traveller header', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
 
     const HeadingComponent = screen.getByText(/^Smart traveller$/i)
     expect(HeadingComponent).toBeInTheDocument()
   })
 
   it('when no cities, the <Cities /> component is not rendered', async () => {
-    render(<Home />)
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
     expect(screen.queryByTestId('cities')).toBeNull()
   })
 
-  it('loads and displays the <Cities /> comonent with expected cities count', async () => {
-    render(<Home />)
+  it('when still loading it displays the loading text', async () => {
+    render(
+      <MockedProvider mocks={[]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
 
-    await waitFor(() => screen.getByTestId('cities'))
+    const loading = screen.getByText('Loading...')
+    expect(loading).toBeInTheDocument()
+  })
 
-    expect(screen.getByTestId('cities')).toHaveTextContent('London')
-    expect(screen.getByTestId('cities')).toHaveTextContent('Brighton')
+  it('when load fails it displays the error text', async () => {
+    const citiesMock = {
+      request: {
+        query: CITIES,
+      },
+      result: {
+        errors: [new GraphQLError('Error!')],
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    const error = screen.getByText('Error!')
+    expect(error).toBeInTheDocument()
+  })
+
+  it('loads and displays the <Cities /> component', async () => {
+    const citiesMock = {
+      request: {
+        query: CITIES,
+      },
+      result: {
+        data: { cities: { id: 1, name: 'London', country: 'United Kingdom' } },
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Home />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
   })
 })

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -7,6 +7,7 @@ import { useLazyQuery } from '@apollo/client'
 
 export const Home: FC = () => {
   const [getCities, { loading, error, data }] = useLazyQuery<CitiesData, CitiesVars>(CITIES)
+  // TODO: Implement Show More Functionality
 
   const [filter, setFilter] = useState<string>()
   const handleChange = (event: any) => setFilter(event.target.value)
@@ -19,14 +20,6 @@ export const Home: FC = () => {
       },
     })
 
-  if (loading) {
-    return <p>Loading...</p>
-  }
-
-  if (error) {
-    return <p>Error!</p>
-  }
-
   return (
     <VStack spacing="8">
       <Heading as="h1">Smart traveller</Heading>
@@ -36,7 +29,8 @@ export const Home: FC = () => {
           <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} onClick={handleSearch} />} />
         </InputGroup>
 
-        {data != undefined && <Cities cities={data.cities.cities} filter={filter} />}
+        {error && <p>Error!</p>}
+        {!error && <Cities cities={data?.cities?.cities} filter={filter} isLoading={loading} />}
       </Container>
     </VStack>
   )

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -1,16 +1,15 @@
-import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
 import { Container, InputRightElement, Input, Heading, InputGroup, IconButton, VStack } from '@chakra-ui/react'
 import { Search2Icon } from '@chakra-ui/icons'
-import type { City } from '../../api/src/cities/types'
 import { Cities } from './Cities/Cities'
+import { CITIES, CitiesData, CitiesVars } from './queries'
+import { useQuery } from '@apollo/client'
 
 export const Home: FC = () => {
-  const [cities, setCities] = useState<City[]>([])
+  const { loading, error, data } = useQuery<CitiesData, CitiesVars>(CITIES)
 
-  useEffect(() => {
-    // TODO: Create to API Call
-  }, [])
+  if (loading) return <p>Loading...</p>
+  if (error) return <p>Error!</p>
 
   return (
     <VStack spacing="8">
@@ -19,8 +18,9 @@ export const Home: FC = () => {
         <InputGroup>
           <Input />
           <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} />} />
-          {cities.length !== 0 && <Cities cities={cities} />}
         </InputGroup>
+
+        {data != undefined && data.cities.length !== 0 && <Cities cities={data.cities} />}
       </Container>
     </VStack>
   )

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -20,7 +20,7 @@ export const Home: FC = () => {
           <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} />} />
         </InputGroup>
 
-        {data != undefined && data.cities.length !== 0 && <Cities cities={data.cities} />}
+        {data != undefined && <Cities cities={data.cities.cities} />}
       </Container>
     </VStack>
   )

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -19,6 +19,7 @@ export const Home: FC = () => {
       },
     })
 
+  // TODO: Fix when loading all items it removes the search box
   if (loading) {
     return <p>Loading...</p>
   }

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -3,7 +3,7 @@ import { Container, InputRightElement, Input, Heading, InputGroup, IconButton, V
 import { Search2Icon } from '@chakra-ui/icons'
 import { Cities } from './Cities/Cities'
 import { CITIES, CitiesData, CitiesVars } from './queries'
-import { useLazyQuery, useQuery } from '@apollo/client'
+import { useLazyQuery } from '@apollo/client'
 
 export const Home: FC = () => {
   const [getCities, { loading, error, data }] = useLazyQuery<CitiesData, CitiesVars>(CITIES)
@@ -19,7 +19,6 @@ export const Home: FC = () => {
       },
     })
 
-  // TODO: Fix when loading all items it removes the search box
   if (loading) {
     return <p>Loading...</p>
   }

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -1,16 +1,27 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import type { FC } from 'react'
 import { Container, InputRightElement, Input, Heading, InputGroup, IconButton, VStack } from '@chakra-ui/react'
 import { Search2Icon } from '@chakra-ui/icons'
+import type { City } from '../../api/src/cities/types'
+import { Cities } from './Cities/Cities'
 
-export const Home: FC = () => (
-  <VStack spacing="8">
-    <Heading as="h1">Smart traveller</Heading>
-    <Container maxW="container.md">
-      <InputGroup>
-        <Input />
-        <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} />} />
-      </InputGroup>
-    </Container>
-  </VStack>
-)
+export const Home: FC = () => {
+  const [cities, setCities] = useState<City[]>([])
+
+  useEffect(() => {
+    // TODO: Create to API Call
+  }, [])
+
+  return (
+    <VStack spacing="8">
+      <Heading as="h1">Smart traveller</Heading>
+      <Container maxW="container.md">
+        <InputGroup>
+          <Input />
+          <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} />} />
+          {cities.length !== 0 && <Cities cities={cities} />}
+        </InputGroup>
+      </Container>
+    </VStack>
+  )
+}

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -1,26 +1,42 @@
-import type { FC } from 'react'
+import { FC, useState } from 'react'
 import { Container, InputRightElement, Input, Heading, InputGroup, IconButton, VStack } from '@chakra-ui/react'
 import { Search2Icon } from '@chakra-ui/icons'
 import { Cities } from './Cities/Cities'
 import { CITIES, CitiesData, CitiesVars } from './queries'
-import { useQuery } from '@apollo/client'
+import { useLazyQuery, useQuery } from '@apollo/client'
 
 export const Home: FC = () => {
-  const { loading, error, data } = useQuery<CitiesData, CitiesVars>(CITIES)
+  const [getCities, { loading, error, data }] = useLazyQuery<CitiesData, CitiesVars>(CITIES)
 
-  if (loading) return <p>Loading...</p>
-  if (error) return <p>Error!</p>
+  const [filter, setFilter] = useState<string>()
+  const handleChange = (event: any) => setFilter(event.target.value)
+  const handleSearch = () =>
+    getCities({
+      variables: {
+        filter: {
+          name: filter,
+        },
+      },
+    })
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  if (error) {
+    return <p>Error!</p>
+  }
 
   return (
     <VStack spacing="8">
       <Heading as="h1">Smart traveller</Heading>
       <Container maxW="container.md">
         <InputGroup>
-          <Input />
-          <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} />} />
+          <Input type="search" onChange={handleChange} />
+          <InputRightElement children={<IconButton aria-label="" icon={<Search2Icon />} onClick={handleSearch} />} />
         </InputGroup>
 
-        {data != undefined && <Cities cities={data.cities.cities} />}
+        {data != undefined && <Cities cities={data.cities.cities} filter={filter} />}
       </Container>
     </VStack>
   )

--- a/packages/client/src/Home.tsx
+++ b/packages/client/src/Home.tsx
@@ -6,19 +6,50 @@ import { CITIES, CitiesData, CitiesVars } from './queries'
 import { useLazyQuery } from '@apollo/client'
 
 export const Home: FC = () => {
-  const [getCities, { loading, error, data }] = useLazyQuery<CitiesData, CitiesVars>(CITIES)
-  // TODO: Implement Show More Functionality
+  const [offset, setOffset] = useState(0)
+  const [getCities, { loading, error, data, refetch }] = useLazyQuery<CitiesData, CitiesVars>(CITIES)
 
   const [filter, setFilter] = useState<string>()
   const handleChange = (event: any) => setFilter(event.target.value)
+
   const handleSearch = () =>
     getCities({
       variables: {
         filter: {
           name: filter,
         },
+        limit: 10,
+        offset: 0,
       },
     })
+
+  const handlePrevious = () => {
+    if (offset === 0) {
+      return
+    }
+
+    const newOffset = offset - 10
+    setOffset(newOffset)
+    refetch({
+      filter: {
+        name: filter,
+      },
+      limit: 10,
+      offset: newOffset,
+    })
+  }
+
+  const handleNext = () => {
+    const newOffset = offset + 10
+    setOffset(newOffset)
+    refetch({
+      filter: {
+        name: filter,
+      },
+      limit: 10,
+      offset: newOffset,
+    })
+  }
 
   return (
     <VStack spacing="8">
@@ -30,7 +61,17 @@ export const Home: FC = () => {
         </InputGroup>
 
         {error && <p>Error!</p>}
-        {!error && <Cities cities={data?.cities?.cities} filter={filter} isLoading={loading} />}
+        {!error && (
+          <Cities
+            cities={data?.cities?.cities}
+            filter={filter}
+            isLoading={loading}
+            pagination={{
+              onPreviousClicked: handlePrevious,
+              onNextClicked: handleNext,
+            }}
+          />
+        )}
       </Container>
     </VStack>
   )

--- a/packages/client/src/Visited.test.tsx
+++ b/packages/client/src/Visited.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { GetCitiesRequestSeeder, render } from './test-utils'
+import { Home } from './Home'
+import { Visited } from './Visited'
+
+describe('<Visited /> component', () => {
+  it('renders the error text when fails to load visited cities', async () => {
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithError()
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Visited />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    const error = screen.getByText('Error getting your visited cities')
+    expect(error).toBeInTheDocument()
+  })
+
+  it('renders the <Cities /> component as cities-loading when visited cities query has responded', async () => {
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithVisitedCities(true, [
+      {
+        id: 1,
+        name: 'London',
+        country: 'United Kingdom',
+        visited: true,
+        wishlist: false,
+      },
+    ])
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Visited />
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('cities-loading')).toBeInTheDocument()
+  })
+
+  it('renders the <Cities /> component when visited cities query has responded', async () => {
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithVisitedCities(true, [
+      {
+        id: 1,
+        name: 'London',
+        country: 'United Kingdom',
+        visited: true,
+        wishlist: false,
+      },
+    ])
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <Visited />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+  })
+})

--- a/packages/client/src/Visited.test.tsx
+++ b/packages/client/src/Visited.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react'
 import { MockedProvider } from '@apollo/client/testing'
 import { GetCitiesRequestSeeder, render } from './test-utils'
-import { Home } from './Home'
 import { Visited } from './Visited'
 
 describe('<Visited /> component', () => {

--- a/packages/client/src/Visited.tsx
+++ b/packages/client/src/Visited.tsx
@@ -1,10 +1,26 @@
-import React from 'react'
 import type { FC } from 'react'
 import { Container, Heading } from '@chakra-ui/react'
+import { useQuery } from '@apollo/client'
+import { CITIES, CitiesData, CitiesVars } from './queries'
+import { Cities } from './Cities/Cities'
 
-export const Visited: FC = () => (
-  <>
-    <Heading as="h1">Visited</Heading>
-    <Container centerContent maxW="container.md" flexDir="row"></Container>
-  </>
-)
+export const Visited: FC = () => {
+  const { loading, error, data, refetch } = useQuery<CitiesData, CitiesVars>(CITIES, {
+    fetchPolicy: 'network-only', // Stops catch-first policy to ensure we always get the users latest visited cities
+    variables: {
+      filter: {
+        visited: true,
+      },
+    },
+  })
+
+  return (
+    <>
+      <Heading as="h1">Visited</Heading>
+      <Container centerContent maxW="container.md" flexDir="row">
+        {error && <p>Error getting your visited cities</p>}
+        {!error && <Cities cities={data?.cities?.cities} isLoading={loading} />}
+      </Container>
+    </>
+  )
+}

--- a/packages/client/src/Visited.tsx
+++ b/packages/client/src/Visited.tsx
@@ -19,7 +19,7 @@ export const Visited: FC = () => {
       <Heading as="h1">Visited</Heading>
       <Container centerContent maxW="container.md" flexDir="row">
         {error && <p>Error getting your visited cities</p>}
-        {!error && <Cities cities={data?.cities?.cities} isLoading={loading} />}
+        {!error && <Cities cities={data?.cities?.cities} isLoading={loading} isReadonly={true} />}
       </Container>
     </>
   )

--- a/packages/client/src/WishList.tsx
+++ b/packages/client/src/WishList.tsx
@@ -1,10 +1,27 @@
 import React from 'react'
 import type { FC } from 'react'
 import { Container, Heading } from '@chakra-ui/react'
+import { Cities } from './Cities/Cities'
+import { useQuery } from '@apollo/client'
+import { CITIES, CitiesData, CitiesVars } from './queries'
 
-export const WishList: FC = () => (
-  <>
-    <Heading as="h1">Wish list</Heading>
-    <Container centerContent maxW="container.md" flexDir="row"></Container>
-  </>
-)
+export const WishList: FC = () => {
+  const { loading, error, data, refetch } = useQuery<CitiesData, CitiesVars>(CITIES, {
+    fetchPolicy: 'network-only', // Stops catch-first policy to ensure we always get the users latest visited cities
+    variables: {
+      filter: {
+        wishlist: true,
+      },
+    },
+  })
+
+  return (
+    <>
+      <Heading as="h1">Wish list</Heading>
+      <Container centerContent maxW="container.md" flexDir="row">
+        {error && <p>Error getting your wishlist cities</p>}
+        {!error && <Cities cities={data?.cities?.cities} isLoading={loading} isReadonly={true} />}
+      </Container>
+    </>
+  )
+}

--- a/packages/client/src/Wishlist.test.tsx
+++ b/packages/client/src/Wishlist.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import { GetCitiesRequestSeeder, render } from './test-utils'
+import { WishList } from './WishList'
+
+describe('<WishList /> component', () => {
+  it('renders the error text when fails to load wishlist cities', async () => {
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithError()
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <WishList />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    const error = screen.getByText('Error getting your wishlist cities')
+    expect(error).toBeInTheDocument()
+  })
+
+  it('renders the <Cities /> component as cities-loading when wishlist cities query has responded', async () => {
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithWishlistCities(true, [
+      {
+        id: 1,
+        name: 'London',
+        country: 'United Kingdom',
+        visited: false,
+        wishlist: true,
+      },
+    ])
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <WishList />
+      </MockedProvider>
+    )
+
+    expect(screen.getByTestId('cities-loading')).toBeInTheDocument()
+  })
+
+  it('renders the <Cities /> component when wishlist cities query has responded', async () => {
+    const citiesMock = new GetCitiesRequestSeeder().RespondsWithWishlistCities(true, [
+      {
+        id: 1,
+        name: 'London',
+        country: 'United Kingdom',
+        visited: false,
+        wishlist: true,
+      },
+    ])
+
+    render(
+      <MockedProvider mocks={[citiesMock]} addTypename={false}>
+        <WishList />
+      </MockedProvider>
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0)) // wait for response
+
+    expect(screen.getByTestId('cities')).toBeInTheDocument()
+  })
+})

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -2,6 +2,8 @@ import { gql } from "@apollo/client";
 
 export interface CitiesFilters {
   name?: string
+  visited?: boolean
+  wishlist?: boolean
 }
 
 export interface CitiesMutationInput {

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -1,0 +1,20 @@
+import { gql } from "@apollo/client";
+import { City } from "../../api/src/cities/types";
+
+export interface CitiesData {
+    cities: City[];
+}
+
+export interface CitiesVars {
+}
+
+export const CITIES = gql`
+  query GetCities {
+    cities {
+        cities {
+          name
+          country
+        }
+      }
+  }
+`

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -1,23 +1,33 @@
 import { gql } from "@apollo/client";
 
 export interface CitiesFilters {
-  name: string | undefined
+  name?: string
+}
+
+export interface CitiesMutationInput {
+  input: {
+    id: number,
+    wishlist?: boolean,
+    visited?: boolean
+  }
 }
 
 export interface CityResponse {
   id: number,
   name: string,
-  country: string
+  country: string,
+  visited: boolean,
+  wishlist: boolean
 }
 
 export interface CitiesData {
     cities: {
-      cities: CityResponse[];
+        cities: CityResponse[]
     }
 }
 
 export interface CitiesVars {
-  filter: CitiesFilters | undefined;
+  filter?: CitiesFilters
 }
 
 export const CITIES = gql`
@@ -27,7 +37,21 @@ export const CITIES = gql`
           id
           name
           country
+          visited
+          wishlist
         }
       }
   }
+`
+
+export const UPDATE_CITY = gql`
+mutation UpdateCity($input: CitiesMutationInput) {
+  updateCity(input: $input) {
+      id
+      name
+      country
+      visited
+      wishlist
+  }
+}
 `

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -1,6 +1,11 @@
 import { gql } from "@apollo/client";
 
+export interface CitiesFilters {
+  name: string | undefined
+}
+
 export interface CityResponse {
+  id: number,
   name: string,
   country: string
 }
@@ -12,12 +17,14 @@ export interface CitiesData {
 }
 
 export interface CitiesVars {
+  filter: CitiesFilters | undefined;
 }
 
 export const CITIES = gql`
-  query GetCities {
-    cities {
+  query GetCities($filter: CitiesFilters) {
+    cities(filter: $filter) {
         cities {
+          id
           name
           country
         }

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -30,11 +30,13 @@ export interface CitiesData {
 
 export interface CitiesVars {
   filter?: CitiesFilters
+  limit?: number
+  offset?: number
 }
 
 export const CITIES = gql`
-  query GetCities($filter: CitiesFilters) {
-    cities(filter: $filter) {
+  query GetCities($filter: CitiesFilters, $limit: Int, $offset: Int) {
+    cities(filter: $filter, limit: $limit, offset: $offset) {
         cities {
           id
           name

--- a/packages/client/src/queries.ts
+++ b/packages/client/src/queries.ts
@@ -1,8 +1,14 @@
 import { gql } from "@apollo/client";
-import { City } from "../../api/src/cities/types";
+
+export interface CityResponse {
+  name: string,
+  country: string
+}
 
 export interface CitiesData {
-    cities: City[];
+    cities: {
+      cities: CityResponse[];
+    }
 }
 
 export interface CitiesVars {

--- a/packages/client/src/test-utils.tsx
+++ b/packages/client/src/test-utils.tsx
@@ -62,6 +62,48 @@ export class GetCitiesRequestSeeder implements MockedResponse<Record<string, any
 
     return this
   }
+
+  public RespondsWithVisitedCities(visited?: boolean, cities?: CityResponse[]): GetCitiesRequestSeeder {
+    this.request = {
+      ...this.request,
+      variables: {
+        filter: {
+          visited: visited,
+        },
+      },
+    }
+
+    this.result = {
+      data: {
+        cities: {
+          cities: cities == undefined ? this.cities : cities,
+        },
+      },
+    }
+
+    return this
+  }
+
+  public RespondsWithWishlistCities(wishlist?: boolean, cities?: CityResponse[]): GetCitiesRequestSeeder {
+    this.request = {
+      ...this.request,
+      variables: {
+        filter: {
+          wishlist: wishlist,
+        },
+      },
+    }
+
+    this.result = {
+      data: {
+        cities: {
+          cities: cities == undefined ? this.cities : cities,
+        },
+      },
+    }
+
+    return this
+  }
 }
 
 export class UpdateCityRequestSeeder implements MockedResponse<Record<string, any>> {

--- a/packages/client/src/test-utils.tsx
+++ b/packages/client/src/test-utils.tsx
@@ -2,6 +2,10 @@ import * as React from 'react'
 import type { RenderOptions } from '@testing-library/react'
 import { render } from '@testing-library/react'
 import { ChakraProvider, theme } from '@chakra-ui/react'
+import { MockedResponse } from '@apollo/client/testing'
+import { GraphQLRequest, FetchResult } from '@apollo/client'
+import { CITIES, CityResponse, UPDATE_CITY } from './queries'
+import { GraphQLError } from 'graphql'
 
 const AllProviders = ({ children }: { children?: React.ReactNode }) => (
   <ChakraProvider theme={theme}>{children}</ChakraProvider>
@@ -11,3 +15,111 @@ const customRender = (ui: React.ReactElement, options?: RenderOptions) =>
   render(ui, { wrapper: AllProviders, ...options })
 
 export { customRender as render }
+
+export class GetCitiesRequestSeeder implements MockedResponse<Record<string, any>> {
+  public request: GraphQLRequest
+  public result: FetchResult<Record<string, any>, Record<string, any>, Record<string, any>> | undefined
+  public error?: Error | undefined
+
+  public cities: CityResponse[]
+
+  constructor() {
+    this.request = {
+      query: CITIES,
+    }
+
+    this.cities = [
+      { id: 1, name: 'London', country: 'United Kingdom', visited: false, wishlist: false },
+      { id: 1, name: 'Moscow', country: 'Russia', visited: false, wishlist: false },
+    ]
+  }
+
+  public RespondsWithError(): GetCitiesRequestSeeder {
+    this.result = {
+      errors: [new GraphQLError('Error!')],
+    }
+
+    return this
+  }
+
+  public RespondsWithCities(filter?: string, cities?: CityResponse[]): GetCitiesRequestSeeder {
+    this.request = {
+      ...this.request,
+      variables: {
+        filter: {
+          name: filter,
+        },
+      },
+    }
+
+    this.result = {
+      data: {
+        cities: {
+          cities: cities == undefined ? this.cities : cities,
+        },
+      },
+    }
+
+    return this
+  }
+}
+
+export class UpdateCityRequestSeeder implements MockedResponse<Record<string, any>> {
+  public request: GraphQLRequest
+  public result: FetchResult<Record<string, any>, Record<string, any>, Record<string, any>> | undefined
+  public error?: Error | undefined
+
+  public city: CityResponse
+
+  constructor() {
+    this.request = {
+      query: UPDATE_CITY,
+    }
+
+    this.city = { id: 1, name: 'London', country: 'United Kingdom', visited: false, wishlist: false }
+  }
+
+  public UpdateVisited(visited: boolean): UpdateCityRequestSeeder {
+    this.request = {
+      ...this.request,
+      variables: {
+        input: {
+          id: 1,
+          visited: visited,
+        },
+      },
+    }
+
+    this.result = {
+      data: {
+        cities: {
+          cities: { ...this.city, visited: visited },
+        },
+      },
+    }
+
+    return this
+  }
+
+  public UpdateWishlist(wishlist: boolean): UpdateCityRequestSeeder {
+    this.request = {
+      ...this.request,
+      variables: {
+        input: {
+          id: 1,
+          wishlist: wishlist,
+        },
+      },
+    }
+
+    this.result = {
+      data: {
+        cities: {
+          cities: { ...this.city, wishlist: wishlist },
+        },
+      },
+    }
+
+    return this
+  }
+}

--- a/packages/client/src/test-utils.tsx
+++ b/packages/client/src/test-utils.tsx
@@ -42,13 +42,15 @@ export class GetCitiesRequestSeeder implements MockedResponse<Record<string, any
     return this
   }
 
-  public RespondsWithCities(filter?: string, cities?: CityResponse[]): GetCitiesRequestSeeder {
+  public RespondsWithCities(filter?: string, cities?: CityResponse[], offset?: number): GetCitiesRequestSeeder {
     this.request = {
       ...this.request,
       variables: {
         filter: {
           name: filter,
         },
+        limit: 10,
+        offset: offset == undefined ? 0 : offset,
       },
     }
 


### PR DESCRIPTION
Goals
- Allow the user to search for cities using the provided input.
- Display the cities found on the home page.
- Allow the user to set the visited/wishlist state of a city to true/false via API requests.
- Cities that have visited/wishlist set to true should then appear on their respective pages.